### PR TITLE
Clean up db connection handling and get CI working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
 - export PYTHONWARNINGS=all
 - pip install -e .
 script:
+- export METATLAS_LOCAL_TEST=1
 - if [[ $PYTHON == python=3.4* ]]; then nosetests --exe -v --with-doctest --with-cov
   --cover-package metatlas; else nosetests --exe -v metatlas; fi
 - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 - export PYTHONWARNINGS=all
 - pip install -e .
 script:
-- export METATLAS_LOCAL_TEST=1
+- export METATLAS_LOCAL=1
 - if [[ $PYTHON == python=3.4* ]]; then nosetests --exe -v --with-doctest --with-cov
   --cover-package metatlas; else nosetests --exe -v metatlas; fi
 - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ env:
   global:
   - GH_REF: github.com/biorack/metatlas.git
   - secure: HCQ8gC9b17rPuF4/KnZFlh3crLhlRFKtbUMVJGFuCnz4r7Zna1TELWgmLI0WX6jGgwjjO9ca5aKOOKj0CVGvOPTmIX3VCGEehgxfN0K9pdE9eUlaN047hh32CrTxtik97jxImvPnbni/QmwI3/xI/XrPj2U5iUm38h/WDg+sTPU=
-notifications:
-  email:
-    - aitatanit@gmail.com
-    - bpbowen@lbl.gov
 before_install:
 - sudo apt-add-repository "deb http://cran.stat.ucla.edu/bin/linux/ubuntu precise/"
 - sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deploy: gh-pages
 docs: clean
 	export SPHINXOPTS=-W
 	pip install sphinx-bootstrap-theme numpydoc sphinx ghp-import
-	make -C docs html
+	export METATLAS_LOCAL=1; make -C docs html
 
 gh-pages:
 	git checkout master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,7 @@ html_theme_path =  sphinx_bootstrap_theme.get_html_theme_path()
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['source/static']
+#html_static_path = ['source/static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -80,6 +80,7 @@ Add in index and specify type for inchi keys
     
 Add index for many-to-many tables
 ::
+
     ALTER TABLE compoundidentifications_compound MODIFY source_id VARCHAR(32);
     ALTER TABLE compoundidentifications_compound ADD INDEX source_id (source_id);
     ALTER TABLE compoundidentifications_compound MODIFY target_id VARCHAR(32);
@@ -92,6 +93,7 @@ Add index for many-to-many tables
 
 Example query that has subqueries
 ::
+
     #select rtreferences.*   
     select rtreferences.rt_peak, rtreferences.rt_min, rtreferences.rt_max, rtreferences.rt_units, rtreferences.last_modified, rtreferences.username
     from rtreferences, compoundidentifications, compoundidentifications_rt_references, compoundidentifications_compound, compounds  

--- a/metatlas/__init__.py
+++ b/metatlas/__init__.py
@@ -12,7 +12,7 @@ from .metatlas_objects import (
     Method, Sample, LcmsRun, FunctionalSet,
     Compound, Reference, IdentificationGrade, CompoundIdentification, Atlas,
     Group, MzIntensityPair, FragmentationReference, RtReference,
-    MzReference, retrieve, store, remove, remove_objects, database,
+    MzReference, retrieve, store, remove, remove_objects, workspace,
     to_dataframe
 )
 #ReferenceDatabase, 

--- a/metatlas/gui.py
+++ b/metatlas/gui.py
@@ -132,7 +132,7 @@ def show_experiments(username=None):
     """Create a gui to browse the available experiments.
     """
     query = 'SELECT DISTINCT username, experiment FROM lcmsruns'
-    db = workspace.connect()
+    db = workspace.get_connection()
     entries = [e for e in db.query(query)]
     experiments = defaultdict(set)
     for entry in entries:

--- a/metatlas/gui.py
+++ b/metatlas/gui.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from IPython.utils import traitlets
 from . import (
-    retrieve, LcmsRun, to_dataframe, database, get_chromatogram,
+    retrieve, LcmsRun, to_dataframe, workspace, get_chromatogram,
     get_spectrogram, get_info
 )
 from .object_helpers import format_timestamp
@@ -132,7 +132,8 @@ def show_experiments(username=None):
     """Create a gui to browse the available experiments.
     """
     query = 'SELECT DISTINCT username, experiment FROM lcmsruns'
-    entries = [e for e in database.query(query)]
+    db = workspace.connect()
+    entries = [e for e in db.query(query)]
     experiments = defaultdict(set)
     for entry in entries:
         if entry['experiment']:

--- a/metatlas/helpers/dill2plots.py
+++ b/metatlas/helpers/dill2plots.py
@@ -541,7 +541,7 @@ class adjust_mz_for_selected_compound(object):
 
         min_x = self.ax.get_xlim()[0]
         max_x = self.ax.get_xlim()[1]
-        print min_x,max_x
+        print(min_x,max_x)
         
         self.mz_peak_ax = plt.axes([0.09, 0.05, 0.81, 0.03], axisbg=self.slider_color)
         self.mz_max_ax = plt.axes([0.09, 0.1, 0.81, 0.03], axisbg=self.slider_color)
@@ -1201,12 +1201,12 @@ def make_identification_figure(input_fname = '',input_dataset = [],include_lcmsr
     compound_names = ma_data.get_compound_names(data)[0]
     file_names = ma_data.get_file_names(data)
 
-    print 'loading preexisting compound identifications'
+    print('loading preexisting compound identifications')
 
     ids = metob.retrieve('CompoundIdentification',username='*')
     frag_refs = [cid for cid in ids if cid.frag_references]
     
-    print 'getting spectra from files'
+    print('getting spectra from files')
     
     
     for compound_idx in range(len(compound_names)):

--- a/metatlas/helpers/mzmine_helpers.py
+++ b/metatlas/helpers/mzmine_helpers.py
@@ -111,7 +111,7 @@ def make_mzmine_scripts(mzml_files,
     base_qsub_text = base_qsub_text.replace(base_batch_file,new_batch_file)
     with open(new_qsub_file,'w') as fid:
         fid.write(base_qsub_text)
-    print 'qsub',new_qsub_file
+    print('qsub',new_qsub_file)
 
     # 3. submit job with NEWT
     # from requests import Session

--- a/metatlas/helpers/rt_corrector.py
+++ b/metatlas/helpers/rt_corrector.py
@@ -95,9 +95,12 @@ create_atlas_btn = widgets.Button(description="Create Atlas from Dill")
 modify_atlas_btn = widgets.Button(description="Modify Selected Atlas")
 
 # text box that holds the selected atlas' RT values for the selected compound. displays
-atlas_ref_vals = widgets.Text(description="RT values for compound in Atlas")
-atlas_ref_vals.value = "RT values for compound in Atlas go here"
-atlas_ref_vals.color = 'red'
+atlas_ref_vals = widgets.Text(
+    description="RT values for compound in Atlas",
+    value = "RT values for compound in Atlas go here",
+    color = 'red'
+)
+
 
 # sliders for the user to change the RT values
 rtmin_widget = FloatSlider()

--- a/metatlas/helpers/rt_corrector_old.py
+++ b/metatlas/helpers/rt_corrector_old.py
@@ -95,9 +95,12 @@ create_atlas_btn = widgets.Button(description="Create Atlas from Dill")
 modify_atlas_btn = widgets.Button(description="Modify Selected Atlas")
 
 # text box that holds the selected atlas' RT values for the selected compound. displays
-atlas_ref_vals = widgets.Text(description="RT values for compound in Atlas")
-atlas_ref_vals.value = "RT values for compound in Atlas go here"
-atlas_ref_vals.color = 'red'
+atlas_ref_vals = widgets.Text(
+    description="RT values for compound in Atlas",
+    value = "RT values for compound in Atlas go here",
+    color = 'red'
+)
+
 
 # sliders for the user to change the RT values
 rtmin_widget = FloatSlider()

--- a/metatlas/helpers/rt_corrector_v2.py
+++ b/metatlas/helpers/rt_corrector_v2.py
@@ -96,9 +96,11 @@ create_atlas_btn = widgets.Button(description="Create Atlas from Dill")
 modify_atlas_btn = widgets.Button(description="Modify Selected Atlas")
 
 # text box that holds the selected atlas' RT values for the selected compound. displays
-atlas_ref_vals = widgets.Text(description="RT values for compound in Atlas")
-atlas_ref_vals.value = "RT values for compound in Atlas go here"
-atlas_ref_vals.color = 'red'
+atlas_ref_vals = widgets.Text(
+    description="RT values for compound in Atlas",
+    value = "RT values for compound in Atlas go here",
+    color = 'red'
+)
 
 # sliders for the user to change the RT values
 rtmin_widget = FloatSlider()

--- a/metatlas/metatlas_objects.py
+++ b/metatlas/metatlas_objects.py
@@ -56,7 +56,7 @@ def retrieve(object_type, **kwargs):
       List of Metatlas Objects meeting the criteria.  Will return the
       latest version of each object.
     """
-    return WORKSPACE.retrieve(object_type, **kwargs)
+    return workspace.retrieve(object_type, **kwargs)
 
 
 def remove(object_type, **kwargs):
@@ -74,7 +74,7 @@ def remove(object_type, **kwargs):
     if not isinstance(object_type, str):
         print('remove() expects a string argument, use remove_objects() to'
               'delete actual objects.')
-    return WORKSPACE.remove(object_type, **kwargs)
+    return workspace.remove(object_type, **kwargs)
 
 
 def remove_objects(objects, all_versions=True, **kwargs):
@@ -89,7 +89,7 @@ def remove_objects(objects, all_versions=True, **kwargs):
     if isinstance(objects, str):
         print('remove_objects() expects actual objects, use remove() to'
               'remove objects by type.')
-    return WORKSPACE.remove_objects(objects, all_versions, **kwargs)
+    return workspace.remove_objects(objects, all_versions, **kwargs)
 
 
 def store(objects, **kwargs):
@@ -100,7 +100,7 @@ def store(objects, **kwargs):
     objects: Metatlas object or list of Metatlas Objects
         Object(s) to store in the database.
     """
-    WORKSPACE.save_objects(objects, **kwargs)
+    workspace.save_objects(objects, **kwargs)
 
 
 @set_docstring
@@ -478,7 +478,7 @@ class _IdGradeTrait(MetInstance):
         elif isinstance(value, str):
             if value.upper() in ID_GRADES:
                 return ID_GRADES[value.upper()]
-            objects = WORKSPACE.retrieve('identificationgrade', name=value.upper())
+            objects = workspace.retrieve('identificationgrade', name=value.upper())
             if objects:
                 ID_GRADES[value.upper()] = objects[-1]
                 return objects[-1]
@@ -594,7 +594,7 @@ def find_invalid_runs(**kwargs):
 # Singleton Workspace object
 # Must be instantiated after all of the Metatlas Objects
 # are defined so we can get all of the subclasses.
-WORKSPACE = Workspace()
+workspace = Workspace()
 
 
 def to_dataframe(objects):

--- a/metatlas/metatlas_objects.py
+++ b/metatlas/metatlas_objects.py
@@ -595,7 +595,6 @@ def find_invalid_runs(**kwargs):
 # Must be instantiated after all of the Metatlas Objects
 # are defined so we can get all of the subclasses.
 WORKSPACE = Workspace()
-database = WORKSPACE.db
 
 
 def to_dataframe(objects):

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -13,8 +13,6 @@ import socket
 import os.path
 import yaml
 
-import requests
-
 try:
     from traitlets import (
         HasTraits, CUnicode, List, CInt, Instance, Enum,
@@ -26,12 +24,7 @@ except ImportError:
 
 
 # Whether we are running from NERSC
-# the first works from cori and edison, the second works at nersc broadly
-#r = requests.get(r'http://jsonip.com')
-#your_ip= r.json()['ip']
-#ON_NERSC = ('NERSC_HOST' in os.environ) or your_ip.startswith('128.55.')
-ON_NERSC = True
-#as a backup plan, you could use os.path.exists('/project/projectdirs/metatlas')
+ON_NERSC = 'METATLAS_LOCAL_TEST' not in os.environ
 
 
 # Observable List from

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 # Whether we are running from NERSC
-ON_NERSC = 'METATLAS_LOCAL_TEST' not in os.environ
+ON_NERSC = 'METATLAS_LOCAL' not in os.environ
 
 
 # Observable List from

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -162,12 +162,14 @@ class Workspace(object):
         Workspace.instance = self
 
     def connect(self):
+        """Get a single use connection to the database."""
         db = dataset.connect(self.path)
         if 'sqlite' in self.path:
             os.chmod(self.path[10:], 0o775)
         return db
 
     def convert_to_double(self, table, entry):
+        """Convert a table to double type."""
         db = self.connect()
         try:
             db.query('alter table `%s` modify `%s` double' % (table, entry))
@@ -175,6 +177,7 @@ class Workspace(object):
             print(e)
 
     def save_objects(self, objects, _override=False):
+        """Save objects to the database"""
         if not isinstance(objects, (list, set)):
             objects = [objects]
         self._seen = dict()
@@ -206,6 +209,7 @@ class Workspace(object):
             db[table_name].insert_many(inserts)
 
     def create_link_tables(self, klass):
+        """Create a link table in the database of the given trait klass"""
         name = self.table_name[klass]
         db = self.connect()
         for (tname, trait) in klass.class_traits().items():
@@ -285,6 +289,7 @@ class Workspace(object):
                 self.convert_to_double(table_name, tname)
 
     def retrieve(self, object_type, **kwargs):
+        """Retrieve an object from the database."""
         object_type = object_type.lower()
         klass = self.subclass_lut.get(object_type, None)
         db = self.connect()
@@ -367,6 +372,7 @@ class Workspace(object):
         return items
 
     def remove(self, object_type, **kwargs):
+        """Remove an object from the database"""
         override = kwargs.pop('_override', False)
         if not override:
             msg = 'Are you sure you want to delete the entries? (Y/N)'
@@ -431,6 +437,7 @@ class Workspace(object):
         print('Removed')
 
     def remove_objects(self, objects, all_versions=True, **kwargs):
+        """Remove a list of objects from the database."""
         if not isinstance(objects, (list, set)):
             objects = [objects]
         if not objects:

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -184,9 +184,9 @@ class Workspace(object):
         self._link_updates = defaultdict(list)
         self._updates = defaultdict(list)
         self._inserts = defaultdict(list)
-        db = self.connect()
         for obj in objects:
-            self._save(obj, _override)
+            self._get_save_data(obj, _override)
+        db = self.connect()
         for (table_name, updates) in self._link_updates.items():
             if table_name not in db:
                 continue
@@ -223,8 +223,8 @@ class Workspace(object):
                                 target_table=uuid.uuid4().hex)
                     db[table_name].insert(link)
 
-    def _save(self, obj, override=False):
-        """Save an object to the database"""
+    def _get_save_data(self, obj, override=False):
+        """Get the data that will be used to save an object to the database"""
         if obj.unique_id in self._seen:
             return
         if isinstance(obj, Stub):
@@ -250,7 +250,7 @@ class Workspace(object):
                 # create an entry in the table for each item
                 # store the item in its own table
                 for subvalue in value:
-                    self._save(subvalue, override)
+                    self._get_save_data(subvalue, override)
                     link = dict(source_id=obj.unique_id,
                                 head_id=obj.head_id,
                                 target_id=subvalue.unique_id,
@@ -267,7 +267,7 @@ class Workspace(object):
                 # itself
                 else:
                     state[tname] = value.unique_id
-                    self._save(value, override)
+                    self._get_save_data(value, override)
             elif changed:
                 value = getattr(obj, tname)
                 # store the raw value in this table

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -163,7 +163,7 @@ class Workspace(object):
 
     def get_connection(self):
         """Get a single-use connection to the database."""
-        db = dataset.get_connection(self.path)
+        db = dataset.connect(self.path)
         if 'sqlite' in self.path:
             os.chmod(self.path[10:], 0o775)
         return db

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -162,14 +162,14 @@ class Workspace(object):
         Workspace.instance = self
 
     def connect(self):
-        """Get a single use connection to the database."""
+        """Get a single-use connection to the database."""
         db = dataset.connect(self.path)
         if 'sqlite' in self.path:
             os.chmod(self.path[10:], 0o775)
         return db
 
     def convert_to_double(self, table, entry):
-        """Convert a table to double type."""
+        """Convert a table column to double type."""
         db = self.connect()
         try:
             db.query('alter table `%s` modify `%s` double' % (table, entry))
@@ -224,6 +224,7 @@ class Workspace(object):
                     db[table_name].insert(link)
 
     def _save(self, obj, override=False):
+        """Save an object to the database"""
         if obj.unique_id in self._seen:
             return
         if isinstance(obj, Stub):

--- a/metatlas/object_helpers.py
+++ b/metatlas/object_helpers.py
@@ -161,16 +161,16 @@ class Workspace(object):
         self.seen = dict()
         Workspace.instance = self
 
-    def connect(self):
+    def get_connection(self):
         """Get a single-use connection to the database."""
-        db = dataset.connect(self.path)
+        db = dataset.get_connection(self.path)
         if 'sqlite' in self.path:
             os.chmod(self.path[10:], 0o775)
         return db
 
     def convert_to_double(self, table, entry):
         """Convert a table column to double type."""
-        db = self.connect()
+        db = self.get_connection()
         try:
             db.query('alter table `%s` modify `%s` double' % (table, entry))
         except Exception as e:
@@ -186,7 +186,7 @@ class Workspace(object):
         self._inserts = defaultdict(list)
         for obj in objects:
             self._get_save_data(obj, _override)
-        db = self.connect()
+        db = self.get_connection()
         for (table_name, updates) in self._link_updates.items():
             if table_name not in db:
                 continue
@@ -211,7 +211,7 @@ class Workspace(object):
     def create_link_tables(self, klass):
         """Create a link table in the database of the given trait klass"""
         name = self.table_name[klass]
-        db = self.connect()
+        db = self.get_connection()
         for (tname, trait) in klass.class_traits().items():
             if isinstance(trait, MetList):
                 table_name = '_'.join([name, tname])
@@ -293,7 +293,7 @@ class Workspace(object):
         """Retrieve an object from the database."""
         object_type = object_type.lower()
         klass = self.subclass_lut.get(object_type, None)
-        db = self.connect()
+        db = self.get_connection()
         if object_type not in db:
             if not klass:
                 raise ValueError('Unknown object type: %s' % object_type)
@@ -408,7 +408,7 @@ class Workspace(object):
                 clauses.append('%s = "%s"' % (key, value))
         query += ' and '.join(clauses)
         query += ')'
-        db = self.connect()
+        db = self.get_connection()
         if not clauses:
             query = query.replace(' where ()', '')
         # check for lists items that need removal
@@ -458,7 +458,7 @@ class Workspace(object):
         ids = defaultdict(list)
         username = getpass.getuser()
         attr = 'head_id' if all_versions else 'unique_id'
-        db = self.connect()
+        db = self.get_connection()
         for obj in objects:
             if not override and obj.username != username:
                 continue

--- a/metatlas/tests/test_metatlas_objects.py
+++ b/metatlas/tests/test_metatlas_objects.py
@@ -204,10 +204,10 @@ def test_user_preserve():
 
 def test_store_all():
     items = []
-    for klass in mo.WORKSPACE.subclass_lut.values():
+    for klass in mo.workspace.subclass_lut.values():
         items.append(klass())
     mo.store(items)
-    for klass in mo.WORKSPACE.subclass_lut.values():
+    for klass in mo.workspace.subclass_lut.values():
         name = klass.__name__
         assert len(mo.retrieve(name))
 


### PR DESCRIPTION
The logic used to check the integrity of the existing connection stopped working, so now we always get a fresh connection and let the garbage collector handle the previous one.  Removes the extra connection to the database, instead exporting the `workspace` object itself at the top level.

Use the `METATLAS_LOCAL` environment variable to signal that we not running on NERSC.  
Clean up Python 3 compat and docs build.