### PR TITLE
Issue: When the pipeline is run with only MS1 data and empty hits dat…

### DIFF
--- a/metatlas/helpers/dill2plots.py
+++ b/metatlas/helpers/dill2plots.py
@@ -1545,7 +1545,7 @@ def file_with_max_ms1_intensity(data,compound_idx):
     idx = None
     my_max = 0
     for i,d in enumerate(data):
-        if 'intensity' in d[compound_idx]['data']['eic'].keys():
+        if 'intensity' in d[compound_idx]['data']['eic'].keys() and d[compound_idx]['data']['eic']['intensity'] != []:
             temp = max(d[compound_idx]['data']['eic']['intensity'])
             if temp > my_max:
                 my_max = temp


### PR DESCRIPTION
…aframe is provided, RT adjuster throws an error while calculating file with highest MS1 intensity where the EIC intensity profile is empty. Code Fix: additional check is implemented to check for empty EIC profile