### PR TITLE
feat: unrestricted other sync

### DIFF
--- a/utils/sync_to_aws.sh
+++ b/utils/sync_to_aws.sh
@@ -17,14 +17,8 @@ aws s3 sync --storage-class GLACIER \
             --color off \
             --no-progress \
             --exclude '*' \
-            --exclude '*/other/*' \
-            --exclude '*/other/*/*' \
             --include '*.raw' \
-            --include '*/other/*.sld' \
-            --include '*/other/*.csv' \
-            --include '*/other/*.cmbx' \
-            --include '*/other/*/*.csv' \
-            --include '*/other/*/*.pdf' \
+            --include '*/other/*' \
             "${nersc_raw_data}/${1}" \
 	    "${s3_raw_data}/${1}" \
 	    2>&1 \


### PR DESCRIPTION
Data sync will now copy all files from "/other/*" to aws to avoid missing critical files with arbtrary filetypes. 