### PR TITLE
Remove Easy-IC Signal During Conversion

### DIFF
--- a/metatlas/io/mzml_loader.py
+++ b/metatlas/io/mzml_loader.py
@@ -21,7 +21,7 @@ warnings.filterwarnings("ignore", module="plotly")
 # home directory, you get a warning.
 from pymzml.run import Reader
 
-# from metatlas import __version__
+from metatlas import __version__
 
 DEBUG = False
 FORMAT_VERSION = 5
@@ -295,7 +295,7 @@ def _convert(mzml_reader, out_file=None, filter_easyic_signal=True, debug=None):
             table.copy(sortby='mz', newname=name + '_mz')
             table.cols.mz.remove_index()#             info_table.append([info])
         out_file.set_node_attr('/', 'format_version', FORMAT_VERSION)
-        out_file.set_node_attr('/', 'metatlas_version', "test")
+        out_file.set_node_attr('/', 'metatlas_version', __version__)
 
         if debug:
             sys.stdout.write('\nSaving file\n')


### PR DESCRIPTION
Newer Thermo Orbitrap models such as the IQX and Exploris 120 use an internal calibrant to maintaint <1ppm mass error. When the Easy-IC scan setting is set to "scan to scan", the internal calibrant signal is present in every spectrum collected. To eliminate downstream errors, particularly with MS2 spectral matching, this change modifies the file converter to remove the internal calibrant signal during the mzML to HDF5 conversion step. 

This is currently kept on for all files converted, as the internal calibrant signal (fluoranthene) does not appear in real biological samples. It can be easily turned off by changing the argument "filter_easyic_signal" for the "_convert" function. If needed, the code could be further modified to allow for optional signal remove at the converter bash script level. 