### PR TITLE
Update m1 summary function

### DIFF
--- a/metatlas/io/feature_tools.py
+++ b/metatlas/io/feature_tools.py
@@ -315,9 +315,10 @@ def calculate_ms1_summary(df, feature_filter=True):
         summary['label'].append(label_group)
         summary['num_datapoints'].append(label_data['i'].count())
         summary['peak_area'].append(label_data['i'].sum())
+        sum_intensity = label_data['i'].sum()
         idx = label_data['i'].idxmax()
         summary['peak_height'].append(label_data.loc[idx,'i'])
-        summary['mz_centroid'].append(sum(label_data['i']*label_data['mz'])/float(summary['peak_area'][0]))
+        summary['mz_centroid'].append(sum(label_data['i']*label_data['mz'])/sum_intensity)
         summary['rt_peak'].append(label_data.loc[idx,'rt'])
 
     return pd.DataFrame(summary)


### PR DESCRIPTION
@benbowen identified a bug in the updated MS1 summary calculation where the mz centroid is calculated with the wrong denominator. This commit fixes the issue by summing the intensities rather than taking the first element of the intensity list.