### PR TITLE
Update if statement in write_msms_fragment_ions

### DIFF
--- a/metatlas/io/targeted_output.py
+++ b/metatlas/io/targeted_output.py
@@ -231,7 +231,7 @@ def write_msms_fragment_ions(
     out = []
     for compound_idx, _ in enumerate(data[0]):
         max_vars = get_max_precursor_intensity(data, compound_idx)
-        if max_vars.file_idx:
+        if max_vars.file_idx is not None:
             out.append(
                 get_spectra_strings(
                     data,


### PR DESCRIPTION
The function write_msms_fragment_ions() inside targeted_output.py is used periodically by Katherine for specific purposes (e.g. custom workflow JGI-C18-no-filtering) and can be turned on with export_msms_fragment_ions = True in the first code block of a HILIC or C18 targeted analysis. There is an if statement in this write_msms_fragment_ions() function which asks "if file index, then"; file index is an integer and can be 0, so when it is 0 then this loop does not proceed (translates to False) when it should. This was changed to "if file index is not None, then"; this works because a missing file index defaults to None type. 