### PR TITLE
Compound id bug

### DIFF
--- a/metatlas/io/targeted_output.py
+++ b/metatlas/io/targeted_output.py
@@ -96,6 +96,7 @@ def write_identifications_spreadsheet(
         use_labels=True,
         min_msms_score=0.01,
         min_num_frag_matches=1,
+        ppm_tolerance = mz_tolerance,
         polarity=ids.short_polarity,
         overwrite=overwrite,
         data_sheets=False,  # eliminates output of the legacy 'data_sheets' dir but not '{POL}_data_sheets'

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -20,18 +20,30 @@ from metatlas.tools import spectralprocessing as sp
 
 logger = logging.getLogger(__name__)
 
-loose_param = {'min_intensity': 1e3,
-               'rt_tolerance': .25,
-               'mz_tolerance': 25,
-               'min_msms_score': 0.3, 'allow_no_msms': True,
-               'min_num_frag_matches': 1,  'min_relative_frag_intensity': .01}
+# loose_param = {'min_intensity': 1e3,
+#                'rt_tolerance': .25,
+#                'mz_tolerance': 25,
+#                'min_msms_score': 0.3, 'allow_no_msms': True,
+#                'min_num_frag_matches': 1,  'min_relative_frag_intensity': .01}
 
-strict_param = {'min_intensity': 1e5,
-                'rt_tolerance': .25,
-                'mz_tolerance': 5,
-                'min_msms_score': .6, 'allow_no_msms': False,
-                'min_num_frag_matches': 3, 'min_relative_frag_intensity': .1}
+# strict_param = {'min_intensity': 1e5,
+#                 'rt_tolerance': .25,
+#                 'mz_tolerance': 5,
+#                 'min_msms_score': .6, 'allow_no_msms': False,
+#                 'min_num_frag_matches': 3, 'min_relative_frag_intensity': .1}
 
+def calculate_compound_total_score(final_df, compound_idx, quality_scores):
+    final_df.loc[compound_idx, 'total_score'] = sum(quality_scores)
+    if final_df.loc[compound_idx, 'msms_quality'] == -1:
+        final_df.loc[compound_idx, 'msi_level'] = "REMOVE, INVALIDATED BY BAD MSMS MATCH"
+    elif statistics.median(quality_scores) < 1:
+        final_df.loc[compound_idx, 'msi_level'] = "putative"
+    elif final_df.loc[compound_idx, 'total_score'] == 3:
+        final_df.loc[compound_idx, 'msi_level'] = "Exceeds Level 1"
+    else:
+        final_df.loc[compound_idx, 'msi_level'] = "Level 1"
+    return final_df
+                
 def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msms_hits_df = None,
                      include_lcmsruns = [], exclude_lcmsruns = [], include_groups = [], exclude_groups = [],
                      output_loc: Optional[Path] = None,
@@ -272,15 +284,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_quality'] = ''
         quality_scores = [final_df.loc[compound_idx, x] for x in ['msms_quality', 'mz_quality', 'rt_quality']]
         if all(isinstance(x, (int, float)) for x in quality_scores):
-            final_df.loc[compound_idx, 'total_score'] = sum(quality_scores)
-            if final_df.loc[compound_idx, 'msms_quality'] == -1:
-                final_df.loc[compound_idx, 'msi_level'] = "REMOVE, INVALIDATED BY BAD MSMS MATCH"
-            elif statistics.median(quality_scores) < 1:
-                final_df.loc[compound_idx, 'msi_level'] = "putative"
-            elif sum(quality_scores) == 3:
-                final_df.loc[compound_idx, 'msi_level'] = "Exceeds Level 1"
-            else:
-                final_df.loc[compound_idx, 'msi_level'] = "Level 1"
+            final_df = calculate_compound_total_score(final_df, compound_idx, quality_scores)
         else:
             final_df.loc[compound_idx, 'total_score'] = ""
             final_df.loc[compound_idx, 'msi_level'] = ""
@@ -299,8 +303,15 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_numberofions'] = len(mz_sample_matches)
             final_df.loc[compound_idx, 'msms_matchingions'] = ','.join(['%5.3f'%m for m in mz_sample_matches])
             if len(mz_sample_matches) == 1:
-                # Set score to zero when there is only one matching ion. precursor intensity is set as score in such cases and need to be set to 0 for final identification.
-                final_df.loc[compound_idx, 'msms_score'] = 0.0
+                if abs(final_df[compound_idx, 'msms_matchingions'][0] - final_df.loc[compound_idx, 'exact_mass']) <= ppm_tolerance:
+                    # Set score to zero when the single matching fragment ion is the precursor.
+                    final_df.loc[compound_idx, 'msms_score'] = 0.0
+                    # Then, overwrite the 'MSMS Score (0 to 1)' column of COMPOUND IDENTIFICATION SCORES
+                    final_df.loc[compound_idx, 'msms_quality'] = 0
+                    # Last, recalculate total score of COMPOUND IDENTIFICATION SCORES
+                    final_df = calculate_compound_total_score(final_df, compound_idx, quality_scores)
+                else: # When single matching fragment ion is not the precursor, set score to best.
+                    final_df.loc[compound_idx, 'msms_score'] = float("%.4f" % scores[0])
             else:
                 final_df.loc[compound_idx, 'msms_score'] = float("%.4f" % scores[0])
         else:

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -304,11 +304,11 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_matchingions'] = ','.join(['%5.3f'%m for m in mz_sample_matches])
             if len(mz_sample_matches) == 1:
                 single_matching_ion = float(final_df.loc[compound_idx, 'msms_matchingions'].split(',')[0])
-                precursor_mass = float(final_df.loc[compound_idx, 'exact_mass'])
+                precursor_mass = mz_theoretical
                 if abs(single_matching_ion - precursor_mass) <= ppm_tolerance:
                     logger.info("Notice! Single matching MSMS fragment ion %s is within ppm tolerance (%s) of the precursor mass (%s) for %s. Setting MSMS score to zero.", single_matching_ion, ppm_tolerance, precursor_mass, final_df.loc[compound_idx, 'identified_metabolite'])
                     # Set score to zero when the single matching fragment ion is the precursor.
-                    final_df.loc[compound_idx, 'identification_notes'] = "Single matching fragment ion is the precursor."
+                    final_df.loc[compound_idx, 'ms2_notes'] = "Single matching fragment ion is the precursor; " + final_df.loc[compound_idx, 'ms2_notes']
                     final_df.loc[compound_idx, 'msms_score'] = 0.0
                     # Then, overwrite the 'MSMS Score (0 to 1)' column of COMPOUND IDENTIFICATION SCORES
                     final_df.loc[compound_idx, 'msms_quality'] = 0
@@ -321,7 +321,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
                         final_df.loc[compound_idx, 'msi_level'] = ""
                 else: # When single matching fragment ion is not the precursor, set score to best.
                     logger.info("Notice! Single matching MSMS fragment ion %s is not within ppm tolerance (%s) of the precursor mass (%s) for %s. Setting MSMS score to the best score of %s.", single_matching_ion, ppm_tolerance, precursor_mass, final_df.loc[compound_idx, 'identified_metabolite'], scores[0])
-                    final_df.loc[compound_idx, 'identification_notes'] = "Single matching fragment ion is not the precursor."
+                    final_df.loc[compound_idx, 'ms2_notes'] = "Single matching fragment ion is NOT the precursor; " + final_df.loc[compound_idx, 'ms2_notes']
                     final_df.loc[compound_idx, 'msms_score'] = float("%.4f" % scores[0])
             else:
                 #logger.info("Note: Multiple matching fragment ions found for %s.", final_df.loc[compound_idx, 'identified_metabolite'])

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -303,7 +303,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_numberofions'] = len(mz_sample_matches)
             final_df.loc[compound_idx, 'msms_matchingions'] = ','.join(['%5.3f'%m for m in mz_sample_matches])
             if len(mz_sample_matches) == 1:
-                if abs(final_df[compound_idx, 'msms_matchingions'].split(',')[0] - final_df.loc[compound_idx, 'exact_mass']) <= ppm_tolerance:
+                if abs(final_df.loc[compound_idx, 'msms_matchingions'].split(',')[0] - final_df.loc[compound_idx, 'exact_mass']) <= ppm_tolerance:
                     # Set score to zero when the single matching fragment ion is the precursor.
                     final_df.loc[compound_idx, 'msms_score'] = 0.0
                     # Then, overwrite the 'MSMS Score (0 to 1)' column of COMPOUND IDENTIFICATION SCORES

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -303,7 +303,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_numberofions'] = len(mz_sample_matches)
             final_df.loc[compound_idx, 'msms_matchingions'] = ','.join(['%5.3f'%m for m in mz_sample_matches])
             if len(mz_sample_matches) == 1:
-                if abs(final_df[compound_idx, 'msms_matchingions'][0] - final_df.loc[compound_idx, 'exact_mass']) <= ppm_tolerance:
+                if abs(final_df[compound_idx, 'msms_matchingions'].split(',')[0] - final_df.loc[compound_idx, 'exact_mass']) <= ppm_tolerance:
                     # Set score to zero when the single matching fragment ion is the precursor.
                     final_df.loc[compound_idx, 'msms_score'] = 0.0
                     # Then, overwrite the 'MSMS Score (0 to 1)' column of COMPOUND IDENTIFICATION SCORES

--- a/tests/unit/test_fastanalysis.py
+++ b/tests/unit/test_fastanalysis.py
@@ -1,0 +1,85 @@
+'''unit tests of fastanalysis functions'''
+
+from metatlas.tools import fastanalysis
+import numpy as np
+import pandas as pd
+import statistics
+
+def test_calculate_compound_total_score001():
+    
+    # Create a mock DataFrame
+    final_df = pd.DataFrame({
+        'total_score': [0],
+        'msms_quality': [0],
+        'msi_level': ['']
+    })
+
+    # Define the compound index and quality scores
+    compound_idx = 0
+    quality_scores = [1, 1, 1]
+
+    # Call the function with the test parameters
+    result_df = fastanalysis.calculate_compound_total_score(final_df, compound_idx, quality_scores)
+
+    # Assert that the total_score is the sum of the quality scores
+    assert result_df.loc[compound_idx, 'msi_level'] == "Exceeds Level 1"
+
+
+def test_calculate_compound_total_score002():
+    
+    # Create a mock DataFrame
+    final_df = pd.DataFrame({
+        'total_score': [0],
+        'msms_quality': [0],
+        'msi_level': ['']
+    })
+
+    # Define the compound index and quality scores
+    compound_idx = 0
+    quality_scores = [0, 1, 1]
+
+    # Call the function with the test parameters
+    result_df = fastanalysis.calculate_compound_total_score(final_df, compound_idx, quality_scores)
+
+    # Assert that the total_score is the sum of the quality scores
+    assert result_df.loc[compound_idx, 'msi_level'] == "Level 1"
+
+
+def test_calculate_compound_total_score003():
+    
+    # Create a mock DataFrame
+    final_df = pd.DataFrame({
+        'total_score': [0],
+        'msms_quality': [0],
+        'msi_level': ['']
+    })
+
+    # Define the compound index and quality scores
+    compound_idx = 0
+    quality_scores = [0, 0, 0]
+
+    # Call the function with the test parameters
+    result_df = fastanalysis.calculate_compound_total_score(final_df, compound_idx, quality_scores)
+
+    # Assert that the total_score is the sum of the quality scores
+    assert result_df.loc[compound_idx, 'msi_level'] == "putative"
+
+
+def test_calculate_compound_total_score004():
+    
+    # Create a mock DataFrame
+    final_df = pd.DataFrame({
+        'total_score': [0],
+        'msms_quality': [-1],
+        'msi_level': ['']
+    })
+
+    # Define the compound index and quality scores
+    compound_idx = 0
+    quality_scores = [-1, 0, 0]
+
+    # Call the function with the test parameters
+    result_df = fastanalysis.calculate_compound_total_score(final_df, compound_idx, quality_scores)
+
+    # Assert that the total_score is the sum of the quality scores
+    assert result_df.loc[compound_idx, 'msi_level'] == "REMOVE, INVALIDATED BY BAD MSMS MATCH"


### PR DESCRIPTION
Three main changes were implemented to add more functionality to the targeted workflow:
1. Calculation of total score (from -1 to 3) for each compound and assigning an MSI Level quality was pulled into its own function
2. If only one reference-matching MSMS fragment ion is detected for a given compound, it will check whether the fragement is the precursor or not; if it is, it will give that compound an MSMS score of 0 and MSMS quality of 0, while if it is not, it will keep the MSMS scored calculated with matchMS and give the corresponding MSI Level. It will also print a note into the ms2_notes of the compound id sheet when a single fragment ion is found and tell the reviewer whether it's the precursor or not.
3. New logger statements print to the notebook console warning when only single fragment ions are detected.