### PR TITLE
Atlas Prefilter During RT Alignment

### DIFF
--- a/metatlas/datastructures/analysis_identifiers.py
+++ b/metatlas/datastructures/analysis_identifiers.py
@@ -22,7 +22,6 @@ from metatlas.datastructures.id_types import (
     FileMatchList,
     GroupList,
     GroupMatchList,
-    LcmsRunDict,
     LcmsRunsList,
     Polarity,
     POLARITIES,

--- a/metatlas/tools/atlas_prefilter.py
+++ b/metatlas/tools/atlas_prefilter.py
@@ -1,0 +1,244 @@
+import glob
+import os
+import pandas as pd
+import numpy as np
+import numpy.typing as npt
+from typing import TypeAlias, Optional
+from tqdm.notebook import tqdm
+
+import matchms as mms
+from matchms.similarity import CosineHungarian
+
+from metatlas.io.metatlas_get_data_helper_fun import make_atlas_df
+from metatlas.io import feature_tools as ft
+import metatlas.plots.dill2plots as dp
+from metatlas.datastructures.analysis_identifiers import AnalysisIdentifiers
+from metatlas.datastructures.metatlas_dataset import MetatlasDataset
+from metatlas.tools.notebook import in_papermill
+
+# Typing:
+MS2Spectrum: TypeAlias = npt.NDArray[npt.NDArray[float]]
+
+
+def get_sample_file_paths(ids: AnalysisIdentifiers) -> list[str]:
+    """Return lists of sample hdf5 file paths filtered by polarity."""
+    sample_file_paths = [lcmsrun.hdf5_file for lcmsrun in ids.all_lcmsruns if 'QC' not in lcmsrun.hdf5_file]
+    return sample_file_paths
+
+
+def order_ms2_spectrum(spectrum: MS2Spectrum) -> MS2Spectrum:
+    """Order spectrum by m/z from lowest to highest.
+
+    Ordering spectrum by m/z prevents MatchMS errors during MS/MS scoring.
+    """
+    order_idx = np.argsort(spectrum[0])
+    ordered_spec = np.array([spectrum[0][order_idx], spectrum[1][order_idx]])
+    return ordered_spec
+
+
+def get_sample_data(aligned_atlas_df: pd.DataFrame, sample_files: list[str], ppm_tolerance: int, extra_time: float, polarity: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Collect MS1 and MS2 data from experimental sample data using aligned atlas."""
+
+    experiment_input = ft.setup_file_slicing_parameters(aligned_atlas_df, sample_files, base_dir=os.getcwd(), ppm_tolerance=ppm_tolerance, extra_time=extra_time, polarity=polarity)
+
+    ms1_data = []
+    ms2_data = []
+
+    for file_input in tqdm(experiment_input, unit="file", disable=in_papermill()):
+
+        data = ft.get_data(file_input, save_file=False, return_data=True, ms1_feature_filter=False)
+        data['ms1_summary']['lcmsrun_observed'] = file_input['lcmsrun']
+
+        ms2_summary = ft.calculate_ms2_summary(data['ms2_data'])
+        ms2_summary['lcmsrun_observed'] = file_input['lcmsrun']
+
+        ms1_data.append(data['ms1_summary'])
+        ms2_data.append(ms2_summary)
+
+    ms1_data = pd.concat(ms1_data)
+    ms2_data = pd.concat(ms2_data)
+    ms2_data['spectrum'] = ms2_data['spectrum'].apply(order_ms2_spectrum)
+
+    return (ms1_data, ms2_data)
+
+
+def calculate_ms2_scores(ms2_data_refs_merge: pd.DataFrame, frag_tolerance: float) -> list[float]:
+    """Calculate cosine similarity scores for each feature in the sample MS2 data.
+
+    To maintain parity with the MSMS hits collection, scoring is performed using the Hungarian alignment algorithm.
+    """
+
+    cosine_hungarian = CosineHungarian(tolerance=frag_tolerance)
+    scores = ms2_data_refs_merge.apply(lambda x: cosine_hungarian.pair(x.mms_spectrum_x, x.mms_spectrum_y), axis=1)
+
+    return scores
+
+
+def load_and_filter_msms_refs_file(msms_refs_path: str, polarity: str) -> pd.DataFrame:
+    """Load and filter MSMS refs file.
+
+    In addition to loading and filtering MSMS refs, spectral data is converted to Numpy array format.
+    """
+
+    ref_dtypes = {'database': str, 'id': str, 'name': str,
+                  'spectrum': object, 'decimal': int, 'precursor_mz': float,
+                  'polarity': str, 'adduct': str, 'fragmentation_method': str,
+                  'collision_energy': str, 'instrument': str, 'instrument_type': str,
+                  'formula': str, 'exact_mass': float,
+                  'inchi_key': str, 'inchi': str, 'smiles': str}
+
+    msms_refs_df = pd.read_csv(msms_refs_path, sep='\t', dtype=ref_dtypes)
+    msms_refs_filtered = msms_refs_df[(msms_refs_df['database'] == 'metatlas') & (msms_refs_df['polarity'] == polarity)].copy()
+
+    msms_refs_filtered['spectrum'] = msms_refs_filtered['spectrum'].apply(lambda x: np.asarray(eval(x)))
+    msms_refs_filtered['spectrum'] = msms_refs_filtered['spectrum'].apply(order_ms2_spectrum)
+
+    return msms_refs_filtered
+
+
+def score_ms2_data(ms2_data: pd.DataFrame, aligned_atlas_df: pd.DataFrame,
+                   polarity: str, msms_refs_path: str, frag_tolerance: float) -> pd.DataFrame:
+    """Score collected MS2 data against reference spectra.
+
+    This function merges the MSMS refs with the MS2 data collected from the samples for scoring
+    and calculates scores and number of matching ions.
+    """
+
+    msms_refs = load_and_filter_msms_refs_file(msms_refs_path, polarity)
+
+    ms2_data_refs_merge = pd.merge(ms2_data, aligned_atlas_df[['label', 'inchi_key']], on='label')
+    ms2_data_refs_merge = pd.merge(ms2_data_refs_merge, msms_refs[['id', 'inchi_key', 'spectrum']], on='inchi_key')
+
+    ms2_data_refs_merge['mms_spectrum_x'] = ms2_data_refs_merge.apply(lambda x: mms.Spectrum(x.spectrum_x[0], x.spectrum_x[1], metadata={'precursor_mz': x.precursor_mz}), axis=1)
+    ms2_data_refs_merge['mms_spectrum_y'] = ms2_data_refs_merge.apply(lambda x: mms.Spectrum(x.spectrum_y[0], x.spectrum_y[1], metadata={'precursor_mz': x.precursor_mz}), axis=1)
+
+    ms2_data_refs_merge['mms_out'] = calculate_ms2_scores(ms2_data_refs_merge, frag_tolerance)
+
+    ms2_data_refs_merge['score'] = ms2_data_refs_merge['mms_out'].apply(lambda x: x['score'])
+    ms2_data_refs_merge['matches'] = ms2_data_refs_merge['mms_out'].apply(lambda x: x['matches'])
+
+    return ms2_data_refs_merge
+
+
+def filter_atlas_labels(ms1_data: pd.DataFrame, ms2_data_scored: pd.DataFrame, peak_height: Optional[float], num_points: Optional[int],
+                        msms_score: Optional[float], msms_matches: Optional[int]) -> set[str]:
+    """Filter atlas labels to include only those that pass the MS1 and MS2 thresholds."""
+
+    ms1_data_filtered = ms1_data[ms1_data['peak_height'] >= peak_height] if peak_height is not None else ms1_data
+    ms1_data_filtered = ms1_data_filtered[ms1_data_filtered['num_datapoints'] >= num_points] if num_points is not None else ms1_data_filtered
+    ms1_reduced_labels = set(ms1_data_filtered.label.tolist())
+
+    if msms_score is not None or msms_matches is not None:
+        ms2_data_filtered = ms2_data_scored[ms2_data_scored['score'] >= msms_score] if msms_score is not None else ms2_data_scored
+        ms2_data_filtered = ms2_data_filtered[ms2_data_filtered['matches'] >= msms_matches] if msms_matches is not None else ms2_data_filtered
+        ms2_reduced_labels = set(ms2_data_filtered.label.tolist())
+    else:
+        ms2_reduced_labels = ms1_reduced_labels
+
+    reduced_labels = ms1_reduced_labels.intersection(ms2_reduced_labels)
+
+    return reduced_labels
+
+
+def filter_atlas(aligned_atlas, ids: AnalysisIdentifiers, analysis, data: MetatlasDataset):
+
+    aligned_atlas_df = make_atlas_df(aligned_atlas)
+    sample_file_paths = get_sample_file_paths(ids)
+
+    if analysis.parameters.mz_tolerance_override is not None:
+        mz_tolerance = analysis.parameters.mz_tolerance_override
+    else:
+        mz_tolerance = analysis.parameters.mz_tolerance_default
+
+    ms1_data, ms2_data = get_sample_data(aligned_atlas_df, sample_file_paths, mz_tolerance, data.extra_time, ids.polarity)
+    ms2_data_scored = score_ms2_data(ms2_data, aligned_atlas_df, ids.polarity,
+                                     analysis.parameters.msms_refs, analysis.parameters.frag_mz_tolerance)
+
+    reduced_labels = filter_atlas_labels(ms1_data, ms2_data_scored, analysis.parameters.peak_height, analysis.parameters.num_points,
+                                         analysis.parameters.msms_score, analysis.parameters.msms_matches)
+
+    aligned_filtered_atlas_df = aligned_atlas_df[aligned_atlas_df['label'].isin(reduced_labels)]
+    aligned_filtered_atlas = dp.get_atlas(aligned_atlas.name, aligned_filtered_atlas_df, ids.polarity, mz_tolerance)
+
+    return aligned_filtered_atlas
+
+
+# Prototype Pre-Filter RT-Alignment Functions
+
+
+def extract_file_polarity(file_path: str) -> str:
+    """Extract file polarity from file path.
+
+    Per file naming conventions, field 9 of each (underscore delimited) filename contains the polarity information for that particular file.
+    """
+    return os.path.basename(file_path).split('_')[9]
+
+
+def subset_file_paths(raw_data_dir: str, experiment: str, polarity: str) -> tuple[list[str], list[str]]:
+    """Return lists of QC file paths and sample file paths filtered by polarity.
+
+    Filter polarity is used in this case to retrieve both fast polarity switching (FPS) files and files matching the defined polarity
+    """
+
+    if polarity == 'positive':
+        file_polarity = 'POS'
+        filter_polarity = 'NEG'
+    else:
+        file_polarity = 'NEG'
+        filter_polarity = 'POS'
+
+    all_files = glob.glob(os.path.join(raw_data_dir, experiment, '*.h5'))
+
+    sample_files = [file for file in all_files if extract_file_polarity(file) == file_polarity and 'QC' not in file]
+    qc_files = [file for file in all_files if extract_file_polarity(file) != filter_polarity and 'QC_' in file]
+
+    return (sample_files, qc_files)
+
+
+def get_rt_alignment_ms1_data(rt_alignment_atlas: pd.DataFrame, qc_files: list[str], ppm_tolerance: int,
+                              extra_time: float, polarity: str) -> pd.DataFrame:
+    """Collect all MS1 feature data for each entry in the retention time adjustment atlas."""
+
+    experiment_input = ft.setup_file_slicing_parameters(rt_alignment_atlas, qc_files, base_dir=os.getcwd(), ppm_tolerance=ppm_tolerance, extra_time=extra_time, polarity=polarity)
+
+    ms1_data = []
+    for file_input in experiment_input:
+
+        data = ft.get_data(file_input, save_file=False, return_data=True)
+        data['ms1_summary']['lcmsrun_observed'] = file_input['lcmsrun']
+
+        ms1_data.append(data['ms1_summary'])
+
+    return pd.concat(ms1_data)
+
+
+def align_rt_adjustment_peaks(ms1_data: pd.DataFrame, rt_alignment_atlas: pd.DataFrame) -> tuple[list[float], list[float]]:
+    """align median experimental retention time peaks with rt adjustment atlas peaks."""
+
+    median_experimental_rt_peaks = ms1_data[ms1_data['peak_height'] >= 1e4].groupby('label')['rt_peak'].median()
+    rt_peaks_merged = pd.merge(rt_alignment_atlas[['label', 'rt_peak']], median_experimental_rt_peaks, on='label')
+
+    original_rt_peaks = rt_peaks_merged['rt_peak_x'].tolist()
+    experimental_rt_peaks = rt_peaks_merged['rt_peak_y'].tolist()
+
+    return (original_rt_peaks, experimental_rt_peaks)
+
+
+def adjust_template_atlas_rt_peaks(template_atlas: pd.DataFrame, original_rt_peaks: list[float], experimental_rt_peaks: list[float],
+                                   rt_regression: bool, model_degree: int, rt_window: float) -> pd.DataFrame:
+    """Build and use model to adjust template atlas retention time peaks to match experimental retention time space."""
+
+    aligned_template_atlas = template_atlas.copy()
+
+    if rt_regression:
+        rt_alignment_model = np.polyfit(original_rt_peaks, experimental_rt_peaks, model_degree)
+        aligned_template_atlas['rt_peak'] = aligned_template_atlas['rt_peak'].apply(lambda x: np.polyval(rt_alignment_model, x))
+
+    else:
+        median_offset = np.median(np.array(original_rt_peaks) - np.array(experimental_rt_peaks))
+        aligned_template_atlas['rt_peak'] = aligned_template_atlas['rt_peak'] + median_offset
+
+    aligned_template_atlas['rt_min'] = aligned_template_atlas['rt_peak'] - rt_window
+    aligned_template_atlas['rt_max'] = aligned_template_atlas['rt_peak'] + rt_window
+
+    return aligned_template_atlas

--- a/metatlas/tools/atlas_prefilter.py
+++ b/metatlas/tools/atlas_prefilter.py
@@ -57,6 +57,10 @@ def get_sample_data(aligned_atlas_df: pd.DataFrame, sample_files: list[str], ppm
 
     ms1_data = pd.concat(ms1_data)
     ms2_data = pd.concat(ms2_data)
+
+    df = pd.DataFrame(ms2_data['spectrum'])
+    df.to_csv("/out/ms2_data_array.csv")
+
     ms2_data['spectrum'] = ms2_data['spectrum'].apply(order_ms2_spectrum)
 
     return (ms1_data, ms2_data)

--- a/metatlas/tools/config.py
+++ b/metatlas/tools/config.py
@@ -130,6 +130,7 @@ class RTAlignmentNotebookParameters(BaseNotebookParameters):
     inchi_keys_not_in_model: List[str] = []
     dependent_data_source: str = "median"
     use_poly_model: bool = False
+    use_offset_model: bool = False
     stop_before: Optional[str] = None
     google_folder: str
     msms_refs: Path

--- a/metatlas/tools/config.py
+++ b/metatlas/tools/config.py
@@ -110,6 +110,7 @@ class AnalysisNotebookParameters(BaseNotebookParameters):
     num_points: Optional[int] = None
     peak_height: Optional[float] = None
     msms_score: Optional[float] = None
+    msms_matches: Optional[int] = None
     filter_removed: bool = False
     line_colors: Optional[List[Tuple[str, str]]] = None
     require_all_evaluated: bool = False
@@ -140,6 +141,7 @@ class Atlas(BaseModel):
     unique_id: str
     name: str
     do_alignment: bool = False
+    do_prefilter: bool = False
     rt_offset: float = 0.5
 
     @validator("unique_id")

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -19,7 +19,7 @@ workflows:
             always: ["QC"]
           exclude_groups:
             always: ["NEG"]
-          use_poly_model: True
+          use_poly_model: False
           msms_refs: /global/cfs/cdirs/metatlas/projects/spectral_libraries/msms_refs_v3.tab
           google_folder: 0B-ZDcHbPi-aqZzE5V3hOZFc0dms
     analyses:
@@ -49,6 +49,7 @@ workflows:
           exclude_groups:
             rt_alignment: ["NEG"]
           use_poly_model: True
+          use_offset_model: False
           msms_refs: /global/cfs/cdirs/metatlas/projects/spectral_libraries/msms_refs_v3.tab
           google_folder: 0B-ZDcHbPi-aqZzE5V3hOZFc0dms
     analyses:
@@ -69,7 +70,7 @@ workflows:
             name: HILICz150_ANT20190824_TPL_EMA_Unlab_POS
             unique_id: 89694aa326cd46958d38d8e9066de16c
             do_alignment: True
-            do_prefilter: True
+            do_prefilter: False
           parameters:
             copy_atlas: True
             polarity: positive
@@ -84,8 +85,6 @@ workflows:
             filter_removed: True
             num_points: 5
             peak_height: 4e5
-            msms_score: 0.7
-            msms_matches: 3
             generate_analysis_outputs: True
             slurm_execute: True
   - name: Test-C18
@@ -99,7 +98,8 @@ workflows:
             rt_alignment: ["QC"]
           exclude_groups:
             rt_alignment: ["NEG"]
-          use_poly_model: True
+          use_poly_model: False
+          use_offset_model: True
           msms_refs: /global/cfs/cdirs/metatlas/projects/spectral_libraries/msms_refs_v3.tab
           google_folder: 0B-ZDcHbPi-aqZzE5V3hOZFc0dms
     analyses:
@@ -108,7 +108,7 @@ workflows:
             name: C18_20220215_TPL_EMA_Unlab_NEG
             unique_id: f74a731c590544aba5c3720b346e508e
             do_alignment: True
-            do_prefilter: False
+            do_prefilter: True
             rt_offset: 0.2
           parameters:
             copy_atlas: True
@@ -123,6 +123,7 @@ workflows:
             num_points: 3
             peak_height: 1e6
             msms_score: 0.6
+            msms_matches: 3
             filter_removed: True
             generate_analysis_outputs: True
             slurm_execute: True

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -19,7 +19,7 @@ workflows:
             always: ["QC"]
           exclude_groups:
             always: ["NEG"]
-          use_poly_model: False
+          use_poly_model: True
           msms_refs: /global/cfs/cdirs/metatlas/projects/spectral_libraries/msms_refs_v3.tab
           google_folder: 0B-ZDcHbPi-aqZzE5V3hOZFc0dms
     analyses:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -69,6 +69,7 @@ workflows:
             name: HILICz150_ANT20190824_TPL_EMA_Unlab_POS
             unique_id: 89694aa326cd46958d38d8e9066de16c
             do_alignment: True
+            do_prefilter: True
           parameters:
             copy_atlas: True
             polarity: positive
@@ -83,6 +84,8 @@ workflows:
             filter_removed: True
             num_points: 5
             peak_height: 4e5
+            msms_score: 0.7
+            msms_matches: 3
             generate_analysis_outputs: True
             slurm_execute: True
   - name: Test-C18
@@ -105,6 +108,7 @@ workflows:
             name: C18_20220215_TPL_EMA_Unlab_NEG
             unique_id: f74a731c590544aba5c3720b346e508e
             do_alignment: True
+            do_prefilter: False
             rt_offset: 0.2
           parameters:
             copy_atlas: True

--- a/tests/system/test_rt_alignment.py
+++ b/tests/system/test_rt_alignment.py
@@ -23,6 +23,11 @@ LinearRegression()
 Polynomial model with intercept=0.733 and coefficents=[0.00000, 0.81321, 0.00919]
 groups = 20201106_JGI-AK_PS-KM_505892_OakGall_final_QE-HF_HILICZ_USHXG01583_FPS_MS1_root_0_0_QC, 20201106_JGI-AK_PS-KM_505892_OakGall_final_QE-HF_HILICZ_USHXG01583_POS_MSMS_root_0_0_QC
 atlas = HILICz150_ANT20190824_TPL_QCv3_Unlab_POS
+
+MedianOffset(coef_=array([[1.]]), intercept_=0.04492217884826655)
+Linear model with intercept=0.045 and slope=1.00000
+groups = 20201106_JGI-AK_PS-KM_505892_OakGall_final_QE-HF_HILICZ_USHXG01583_FPS_MS1_root_0_0_QC, 20201106_JGI-AK_PS-KM_505892_OakGall_final_QE-HF_HILICZ_USHXG01583_POS_MSMS_root_0_0_QC
+atlas = HILICz150_ANT20190824_TPL_QCv3_Unlab_POS
 """
     expected_df = {}
     expected_df[
@@ -76,6 +81,15 @@ atlas = HILICz150_ANT20190824_TPL_QCv3_Unlab_POS
             5: 4.878586,
             6: 13.32883,
         },
+        'Relative RT Offset': {
+            0: 1.438622,
+            1: 2.278929,
+            2: 2.602524,
+            3: 2.770266,
+            4: 3.135941,
+            5: 4.878586,
+            6: 13.49007
+        },
         "RT Diff Linear": {
             0: 0.1222508,
             1: -0.2713695,
@@ -93,6 +107,15 @@ atlas = HILICz150_ANT20190824_TPL_QCv3_Unlab_POS
             4: -0.2254138,
             5: 1.776357e-15,
             6: 1.776357e-14,
+        },
+        'RT Diff Offset': {
+            0: 0.4455958,
+            1: 0.01478179,
+            2: 0.06215487,
+            3: 0.0006507599,
+            4: -0.02687692,
+            5: 0.0,
+            6: -0.1612413
         },
     }
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,7 +51,6 @@ def fixture_analysis_ids(sqlite_with_test_config_atlases, lcmsrun, configuration
     analysis_name = "EMA-POS"
     workflow = configuration.get_workflow(workflow_name)
     analysis = workflow.get_analysis(analysis_name)
-    hdf5_file = lcmsrun.hdf5_file
     return ids.AnalysisIdentifiers(
         project_directory=project_directory,
         experiment=experiment,
@@ -60,7 +59,6 @@ def fixture_analysis_ids(sqlite_with_test_config_atlases, lcmsrun, configuration
         configuration=configuration,
         workflow=workflow_name,
         analysis=analysis_name,
-        all_lcmsruns=hdf5_file
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,6 +51,7 @@ def fixture_analysis_ids(sqlite_with_test_config_atlases, lcmsrun, configuration
     analysis_name = "EMA-POS"
     workflow = configuration.get_workflow(workflow_name)
     analysis = workflow.get_analysis(analysis_name)
+    hdf5_file = lcmsrun.hdf5_file
     return ids.AnalysisIdentifiers(
         project_directory=project_directory,
         experiment=experiment,
@@ -59,6 +60,7 @@ def fixture_analysis_ids(sqlite_with_test_config_atlases, lcmsrun, configuration
         configuration=configuration,
         workflow=workflow_name,
         analysis=analysis_name,
+        all_lcmsruns=hdf5_file
     )
 
 

--- a/tests/unit/test_atlas_prefilter.py
+++ b/tests/unit/test_atlas_prefilter.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, line-too-long
+
+"""unit tests of atlas prefilter functions"""
+
+from metatlas.tools import atlas_prefilter as pf
+import numpy as np
+import pandas as pd
+
+
+def test_order_ms2_spectrum():
+
+    unordered_array = np.array([[1e+01,1e+03,1e+05,1e+04,1e+02],[1e+05,1e+03,1e+01,1e+02,1e+04]])
+
+    ordered_array = pf.order_ms2_spectrum(unordered_array)
+
+    assert np.all(ordered_array == np.array([[1e+01,1e+02,1e+03,1e+04,1e+05],[1e+05,1e+04,1e+03,1e+02,1e+01]]))
+
+def test_get_sample_file_paths(analysis_ids):
+
+    ids = analysis_ids
+
+    sample_file_paths = pf.get_sample_file_paths(ids)
+
+    assert sample_file_paths == ids.all_lcmsruns

--- a/tests/unit/test_atlas_prefilter.py
+++ b/tests/unit/test_atlas_prefilter.py
@@ -15,10 +15,8 @@ def test_order_ms2_spectrum():
 
     assert np.all(ordered_array == np.array([[1e+01,1e+02,1e+03,1e+04,1e+05],[1e+05,1e+04,1e+03,1e+02,1e+01]]))
 
-def test_get_sample_file_paths(analysis_ids):
+def test_get_sample_file_paths(analysis_ids, lcmsrun):
 
-    ids = analysis_ids
-
-    sample_file_paths = pf.get_sample_file_paths(ids)
-
-    assert sample_file_paths == ids.all_lcmsruns
+    sample_file_paths = pf.get_sample_file_paths(analysis_ids)
+    
+    assert sample_file_paths == [lcmsrun.hdf5_file]

--- a/tests/unit/test_rt_alignment.py
+++ b/tests/unit/test_rt_alignment.py
@@ -19,7 +19,7 @@ def test_get_rts01(metatlas_dataset):
 def test_plot_actual_vs_aligned_rts01(model):
     arrays = [[]]
     rts_df = pd.DataFrame(data={"1": [], "2": [], "3": [], "4": [], "5": [], "6": []})
-    rt_alignment.plot_actual_vs_aligned_rts(arrays, arrays, rts_df, "file_name", model, model)
+    rt_alignment.plot_actual_vs_aligned_rts(arrays, arrays, rts_df, "file_name", model, model, model)
 
 
 def test_align_atlas(atlas_with_2_cids, model):
@@ -32,8 +32,8 @@ def test_align_atlas(atlas_with_2_cids, model):
     assert len(out.compound_identifications) == 2
 
 
-def test_create_aligned_atlases(atlas_with_2_cids, model, analysis_ids, workflow):
-    atlases = rt_alignment.create_aligned_atlases(model, model, analysis_ids, workflow)
+def test_create_aligned_atlases(model, analysis_ids, metatlas_dataset, workflow):
+    atlases = rt_alignment.create_aligned_atlases(model, model, model, analysis_ids, workflow, metatlas_dataset)
     assert [a.name for a in atlases] == [
         "HILICz150_ANT20190824_TPL_QCv3_Unlab_POS",
         "HILICz150_ANT20190824_PRD_EMA_Unlab_POS_linear_505892_OakGall_final_Test-HILIC_EMA-POS_0",


### PR DESCRIPTION
To accommodate very large atlas sizes, an optional pre-filter feature was added to the retention time alignment routine. This dramatically reduces the size of the atlas used for the targeted analysis, lowering the workload for both the user and the atlas database. 

The pre-filtering step generally works by collecting MS1 and MS2 hits from sample data to the aligned template atlas, then using those hits to filter the atlas based on user defined