### PR TITLE
Fix Pandas DType Incompatibility Warning

### DIFF
--- a/metatlas/plots/dill2plots.py
+++ b/metatlas/plots/dill2plots.py
@@ -2426,7 +2426,13 @@ def make_identification_figure_v2(input_fname: Optional[Path] = None, input_data
         msms_hits_df = msms_hits.reset_index().sort_values('score', ascending=False)
     compound_names = ma_data.get_compound_names(data, use_labels)[0]
     file_names = ma_data.get_file_names(data)
-    match = pd.DataFrame()
+
+    match_dtypes = {'label': str,
+                    'file name': str,
+                    'Matching M/Zs above 1E-3*max': str,
+                    'All matching M/Zs': str}
+
+    match = pd.DataFrame(columns=match_dtypes).astype(match_dtypes)
     disable_interactive_plots()
     plt.clf()
     for compound_idx, _ in enumerate(compound_names):
@@ -2712,7 +2718,55 @@ def export_atlas_to_spreadsheet(atlas, output_filename=None):
     cols.extend([(c, ['mz_references', 0, c]) for c in ['mz', 'mz_tolerance', 'adduct']])
     cols.append(('polarity', ['mz_references', 0, 'detected_polarity']))
 
-    out = pd.DataFrame()
+    cols_dtypes = {'chebi_id': str,
+                   'chebi_url': str,
+                   'creation_time': float,
+                   'description': str,
+                   'formula': str,
+                   'head_id': str,
+                   'hmdb_id': str,
+                   'hmdb_url': str,
+                   'img_abc_id': str,
+                   'inchi': str,
+                   'inchi_key': str,
+                   'iupac_name': str,
+                   'kegg_id': str,
+                   'kegg_url': str,
+                   'last_modified': float,
+                   'lipidmaps_id': str,
+                   'lipidmaps_url': str,
+                   'metacyc_id': str,
+                   'mono_isotopic_molecular_weight': float,
+                   'name': str,
+                   'neutralized_2d_inchi': str,
+                   'neutralized_2d_inchi_key': str,
+                   'neutralized_inchi': str,
+                   'neutralized_inchi_key': str,
+                   'num_free_radicals': float,
+                   'number_components': float,
+                   'permanent_charge': float,
+                   'prev_uid': str,
+                   'pubchem_compound_id': str,
+                   'pubchem_url': str,
+                   'source': str,
+                   'synonyms': str,
+                   'unique_id': str,
+                   'username': str,
+                   'wikipedia_url': str,
+                   'label': str,
+                   'id_notes': str,
+                   'ms1_notes': str,
+                   'ms2_notes': str,
+                   'identification_notes': str,
+                   'rt_min': float,
+                   'rt_max': float,
+                   'rt_peak': float,
+                   'mz': float,
+                   'mz_tolerance': float,
+                   'adduct': str,
+                   'polarity': str}
+
+    out = pd.DataFrame(columns=cols_dtypes).astype(cols_dtypes)
     is_atlas = isinstance(atlas, metob.Atlas)
     compound_ids = atlas.compound_identifications if is_atlas else [i['identification'] for i in atlas[0]]
     for i, my_id in enumerate(compound_ids):

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -365,7 +365,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
             final_df.loc[compound_idx, 'msms_file'] = ""
             final_df.loc[compound_idx, 'msms_rt'] = np.nan
             final_df.loc[compound_idx, 'msms_numberofions'] = np.nan
-            final_df.loc[compound_idx, 'msms_matchingions'] = np.nan
+            final_df.loc[compound_idx, 'msms_matchingions'] = ""
             final_df.loc[compound_idx, 'msms_score'] = np.nan
         final_df.loc[compound_idx, 'mz_adduct'] = cid.mz_references[0].adduct
         final_df.loc[compound_idx, 'mz_theoretical'] = float("%.4f" % mz_theoretical)

--- a/metatlas/tools/fastanalysis.py
+++ b/metatlas/tools/fastanalysis.py
@@ -352,7 +352,7 @@ def make_stats_table(input_fname: Optional[Path] = None, input_dataset = [], msm
                     if all(isinstance(x, (int, float)) for x in quality_scores):
                         final_df = calculate_compound_total_score(final_df, compound_idx, quality_scores)
                     else:
-                        final_df.loc[compound_idx, 'total_score'] = pd.NA
+                        final_df.loc[compound_idx, 'total_score'] = np.nan
                         final_df.loc[compound_idx, 'msi_level'] = ""
                 else: # When single matching fragment ion is not the precursor, set score to best.
                     logger.info("Notice! Single matching MSMS fragment ion %s is not within ppm tolerance (%s) of the precursor mass (%s) for %s. Setting MSMS score to the best score of %s.", single_matching_ion, ppm_tolerance, precursor_mass, final_df.loc[compound_idx, 'identified_metabolite'], scores[0])


### PR DESCRIPTION
This PR adds type specifications for columns in several of the output sheets. This future proofs the code against pandas removing the ability to add data that is different from the column data type, and removes the warning messages during post-annotation.