### PR TITLE
Add atlas to db

### DIFF
--- a/docs/Add_Atlas_to_DB.md
+++ b/docs/Add_Atlas_to_DB.md
@@ -1,0 +1,127 @@
+# Create atlas from CSV and deposit it to metatlas database
+
+## Gather atlas CSV
+
+The metatlas compound atlas you want to create and deposit should be a table in 
+comma-separated value (CSV) format. It may contain many different fields, but
+must contain the following required columns:
+
+`rt_max` - float
+
+`rt_min` - float
+
+`rt_peak` - float
+
+`mz` - float
+
+Additional suggested columns are:
+
+`label` - free ASCII text. For internal stardards atlases, the label column should include a 
+parenthetical indicating 'unlabeled' or the isotopic labeling pattern (e.g. 'U - 13C, 15N')
+
+`inchi_key` - XXXXXXXXXXXXXX-XXXXXXXXXX-X
+
+`polarity` - negative or positive
+
+`adduct` - the adduct of the ionized compound
+
+Once the compound table is in the correct format, move it to a directory on perlmutter
+at NERSC where you have read/write permissions.
+
+## Run the Add_Atlas_to_DB.ipynb notebook
+
+The [Add_Atlas_to_DB.ipynb](
+https://github.com/biorack/metatlas/blob/main/notebooks/reference/Add_Atlas_to_DB.ipynb) notebook will deposit your CSV into the metatlas MySQL database.
+A useful way to run the notebook is to use the [JupyterLab ](https://jupyter.nersc.gov/) server in your web browser
+by starting a 'Login Node' session on Perlmutter. You can read more about how to use the 
+service at NERSC's [Jupyter Overview page](https://docs.nersc.gov/services/jupyter/).
+
+To do this, ensure you have cloned or pulled the most up-to-date version of the [metatlas github repo](https://github.com/biorack/metatlas/tree/main)
+main branch on perlmutter and navigate there within the JupyterLab ecosystem. Open up the notebook at
+``` <REPO_DIR>/notebooks/reference/Add_Atlas_to_DB.ipynb ``` and choose the "Metatlas Targeted" kernel if prompted.
+
+You can also run the notebook on perlmutter from an IDE such as VSCode, ensuring you are using an
+appropriate kernel, [e.g. Metatlas Targeted](https://github.com/biorack/metatlas/blob/main/docker/shifter.kernel.json).
+
+### Set parameters in notebook cells
+
+#### Cell 1
+
+The first cell contains several parameters that should be set by the user.
+
+`csv_atlas_file_name` - direct path (from root) to the atlas CSV file on perlmutter
+
+`atlas_name` - suggested: **C18/HILIC/LIPID**_**date-as-Ymd**_**TPL**_**Workflow**_**Lab/Unlab**_**NEG/POS**
+(e.g., `C18_20240624_TPL_EMA_Unlab_NEG`)
+
+`polarity` - negative or positive
+
+`mz_tolerance` - integer (default is 5), other common values are 10 and 20
+
+`sort_atlas` - True or False (default is True, which sorts atlas ascending by RT and MZ 
+[and optionally compound labeling, see below])
+
+`istd_atlas` - True or False (default is False, meaning this is not an ISTD atlas and
+no isotopically labeled compounds are present in CSV. If True, CSV should have the strings
+"(unlabeled)" or "(_labeling pattern_)" e.g. "(U - 1C, 15N)" in the label column, and
+the notebook will sort the atlas so labeled compunds appear first)
+
+`run_retrieval_check` - True or False (default is False because it takes a while, this tests
+if the deposited atlas has the same number of compounds as the input CSV)
+
+Remaining parameters can be set based on specific needs and usage is described in Cell 1.
+
+#### Cell 2
+
+No user-defined settings are required for this cell. Ensure that the metatlas repo commit 
+you expect (likely, most recent) is printed in the info log below the cell. Keep a heads up
+for Warnings that may indicate incorrect CSV input formatting or conflicting parameters.
+
+#### Cells 3 and 4
+
+Cell 3 defines a function to perform atlas sorting; Cell 4 performs the sort if `sort_atlas`
+is True by reading, sorting, and writing the atlas to an updated CSV.
+
+Sorting helps the analyst who will be using the template notebook for 
+metabolomics workflows and should generally be kept as True. The default behavior 
+of the notebook is to (1) sort your atlas CSV first by retention time (RT)
+and second by mass/charge (MZ), with the lowest values of each appearing first in the 
+final atlas, and (2) write the sorted CSV to a file at the same location as 
+the original CSV (with the suffix "sorted" appended before the ".csv").  If you are
+inputting a file which is in CSV format (required) but whose name does not end in ".csv",
+you will need to ammend this line or update your filename. 
+
+If you are depositing an internal standards atlas with both unlabeled and isotopically labeled
+compounds, also ensure that `istd_atlas` is set to True so the sorting function
+knows to put the labeled compounds first in the final atlas.
+
+Check that the logger info printed under Cell 4 matches your expectations about which CSV (sorted
+or unsorted) will be deposited to the database.
+
+#### Cell 5
+
+This is the main call of the notebook and will:
+
+1. Grab the designated atlas CSV
+2. Run checks on fields/formatting
+3. Transform it to a MySQL table
+4. Deposit it to the local database at NERSC
+5. Assign it the provided name and an auto-generated unique ID
+6. Transform the deposited atlas to a pandas dataframe for optional inspection
+
+Cell 5 is a timed block, and should take on the order of minutes to complete. Once
+completed, it will print to standard output the atlas name and unique IDs for use in 
+metabolomics analysis configs with metatlas workflows.
+
+#### Cell 6
+
+Cell 6 runs an optional check on whether the number of compounds in the input CSV matches the
+number of compounds in the deposited atlas. This is not run by default because retrieval of
+the atlas from MySQL by unique ID is time consuming (>15 minutes). Set the `run_retrieval_check`
+parameter to `True` in Cell 1 to run this check.
+
+## Document the atlas name and unique ID
+
+Important note: To use the newly deposited atlas for metatlas workflows you will need to 
+update the config file(s) with the atlas name and the unique ID (printed after Cell 5), document
+these somewhere.

--- a/docs/Add_Atlas_to_DB.md
+++ b/docs/Add_Atlas_to_DB.md
@@ -1,4 +1,10 @@
-# Create atlas from CSV and deposit it to metatlas database
+# Create metatlas atlas from CSV and deposit into database
+
+## Purpose
+
+This documentation will describe how to convert a CSV containing metabolite
+information (for ISTD, QC, EMA analyses, etc.) into a metatlas MySQL database
+object that can be referenced by name or unique ID.
 
 ## Gather atlas CSV
 

--- a/notebooks/reference/Add_Atlas_to_DB.ipynb
+++ b/notebooks/reference/Add_Atlas_to_DB.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "tags": [
      "parameters"
@@ -31,10 +31,19 @@
     "polarity = None\n",
     "\n",
     "# overrides any mz_tolerance value in the CSV file\n",
-    "mz_tolerance = None\n",
+    "mz_tolerance = 5\n",
     "\n",
+    "# choose to sort the atlas by RT and MZ for analysis\n",
+    "sort_atlas = True\n",
     "\n",
-    "# The rest of this block contains project independent parameters\n",
+    "# is the atlas to be deposited an internal standard atlas (i.e., with unlabeled and labeled compounds)?\n",
+    "istd_atlas = True\n",
+    "\n",
+    "# run a check to see if the number of compounds in deposited atlas matches number in input atlas\n",
+    "# defaulted to False because it can take a non-trivial amount of time for larger atlases\n",
+    "run_retrieval_check = False\n",
+    "\n",
+    "############ The rest of this block contains project independent parameters\n",
     "\n",
     "# to use an older version of the metatlas source code, set this to a commit id,\n",
     "# branch name, or tag. If None, then use the the \"main\" branch.\n",
@@ -64,7 +73,7 @@
     "import logging  # noqa: E402\n",
     "from pathlib import Path  # noqa: E402\n",
     "from IPython.display import Markdown, display  # noqa: E402\n",
-    "\n",
+    "import pandas as pd\n",
     "\n",
     "class StopExecution(Exception):\n",
     "    def _render_traceback_(self):\n",
@@ -72,6 +81,7 @@
     "\n",
     "\n",
     "logger = logging.getLogger(\"metatlas.jupyter\")\n",
+    "\n",
     "kernel_def = \"\"\"{\"argv\":[\"shifter\",\"--entrypoint\",\"--image=ghcr.io/biorack/metatlas/metatlas_shifter:latest\",\"/usr/local/bin/python\",\"-m\",\n",
     "                 \"ipykernel_launcher\",\"-f\",\"{connection_file}\"],\"display_name\": \"Metatlas Targeted\",\"language\": \"python\",\n",
     "                 \"metadata\": { \"debugger\": true }}\"\"\"\n",
@@ -91,9 +101,75 @@
     "except ImportError as err:\n",
     "    logger.critical('CRITICAL: Set notebook kernel to \"Metatlas Targeted\" and re-run notebook.')\n",
     "    raise StopExecution from err\n",
+    "# Check if any required variables are None\n",
+    "if csv_atlas_file_name is None or atlas_name is None or polarity is None:\n",
+    "    raise SystemExit(\"Exiting notebook due to unset variables in cell 1.\")\n",
+    "if \".csv\" not in csv_atlas_file_name:\n",
+    "    logger.info('Warning: if you are sorting this CSV before depositing the atlas, you must input a filename in Cell 1 with the suffix \".csv\" or amend the sort function in the notebook')\n",
     "notebook.setup(log_level, source_code_version_id)\n",
     "from metatlas.plots.dill2plots import make_atlas_from_spreadsheet  # noqa: E402\n",
     "from metatlas.io.metatlas_get_data_helper_fun import make_atlas_df  # noqa: E402"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sort_atlas_csv(input_csv, column1, column2, istd_atlas):\n",
+    "    \"\"\"\n",
+    "    Reads in the atlas CSV, sorts it based on two numeric columns in ascending order\n",
+    "\n",
+    "    Parameters:\n",
+    "    - input_csv: Path to the input CSV file.\n",
+    "    - column1: The first column to sort by.\n",
+    "    - column2: The second column to sort by.\n",
+    "    \"\"\"\n",
+    "    # Read the CSV file into a DataFrame\n",
+    "    df = pd.read_csv(input_csv)\n",
+    "    \n",
+    "    # Sort the DataFrame based on the specified columns in ascending order\n",
+    "    if istd_atlas == True:\n",
+    "        if 'label' in df.columns:\n",
+    "            if 'unlabeled' not in df['label'].values:\n",
+    "                logger.info(\"Warning: The designation 'unlabeled' does not appear in the 'label' column. Only set 'istd_atlas' to True if this is an internal standard atlas with isotopic labeling.\")\n",
+    "            df['rt_peak'] = df.apply(lambda row: row['rt_peak'] + 0.1 if 'unlabeled' in row['label'] else row['rt_peak'], axis=1)\n",
+    "            sorted_df = df.sort_values(by=[column1, column2], ascending=[True, True])\n",
+    "            sorted_df['rt_peak'] = sorted_df.apply(lambda row: row['rt_peak'] - 0.1 if 'unlabeled' in row['label'] else row['rt_peak'], axis=1)\n",
+    "        else:\n",
+    "            logger.info(\"Warning: The 'label' column is missing. Not sorting with heavy isotope compound first even though 'istd_atlas' is set to True.\")\n",
+    "            sorted_df = df.sort_values(by=[column1, column2], ascending=[True, True])\n",
+    "    else:\n",
+    "        sorted_df = df.sort_values(by=[column1, column2], ascending=[True, True])\n",
+    "    \n",
+    "    return(sorted_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if sort_atlas == True:\n",
+    "    \n",
+    "    csv_atlas_file_sorted_name = csv_atlas_file_name.replace(\".csv\", \"_sorted.csv\")\n",
+    "\n",
+    "    sorted_df = sort_atlas_csv(csv_atlas_file_name, \"rt_peak\", 'mz', istd_atlas)\n",
+    "\n",
+    "    logger.info('Writing sorted atlas to ' + csv_atlas_file_sorted_name + ' and selecting for db deposit')\n",
+    "    sorted_df.to_csv(csv_atlas_file_sorted_name, index=False)\n",
+    "    \n",
+    "    input_atlas_file_name = csv_atlas_file_sorted_name\n",
+    "    \n",
+    "else:\n",
+    "\n",
+    "    input_atlas_file_name = csv_atlas_file_name\n",
+    "    \n",
+    "    logger.info('Notice: atlas data not sorted, retaining ' + csv_atlas_file_name + ' for db deposit')\n"
    ]
   },
   {
@@ -111,14 +187,55 @@
    },
    "outputs": [],
    "source": [
+    "%%time\n",
     "assert csv_atlas_file_name is not None\n",
     "assert atlas_name is not None\n",
+    "logger.info('Reading in atlas from ' + input_atlas_file_name + ' and depositing to MySQL database at NERSC')\n",
     "atlas = make_atlas_from_spreadsheet(\n",
-    "    csv_atlas_file_name, atlas_name, filetype=\"csv\", polarity=polarity, store=True, mz_tolerance=mz_tolerance\n",
+    "    input_atlas_file_name, atlas_name, filetype=\"csv\", polarity=polarity, store=True, mz_tolerance=mz_tolerance\n",
     ")\n",
+    "logger.info('Making atlas df from ' + atlas.name + ' for downstream checks')\n",
     "atlas_df = make_atlas_df(atlas)\n",
     "display(Markdown(f\"### Atlas unique_id: {atlas.unique_id}\"))\n",
-    "display(atlas_df)"
+    "display(Markdown(f\"### Atlas name: {atlas.name}\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if run_retrieval_check == True:\n",
+    "\n",
+    "    import pandas as pd\n",
+    "    from metatlas.datastructures.utils import get_atlas\n",
+    "\n",
+    "    def atlas_id_to_df(atlas_unique_id: str) -> pd.DataFrame:\n",
+    "        \"\"\"Retrieve atlas from database using unique id and create DataFrame from compound identification data.\"\"\"\n",
+    "\n",
+    "        atlas = get_atlas(atlas_unique_id)\n",
+    "\n",
+    "        atlas_df = make_atlas_df(atlas)\n",
+    "\n",
+    "        return atlas_df\n",
+    "    \n",
+    "    # Ensure atlas can be retrieved from database\n",
+    "    retrieved_atlas_df = atlas_id_to_df(atlas.unique_id)\n",
+    "    \n",
+    "    # Convert input atlas to df\n",
+    "    input_atlas_df = pd.read_csv(input_atlas_file_name)\n",
+    "    \n",
+    "    # Check dataframe dims against expectations\n",
+    "    if input_atlas_df.shape[0] == retrieved_atlas_df.shape[0]:\n",
+    "        \n",
+    "        logger.info('Input and deposited atlas have the same number of compounds.')\n",
+    "    \n",
+    "    else:\n",
+    "        \n",
+    "        logger.info('Warning! Input and deposited atlas do not have the same number of compounds.')"
    ]
   }
  ],
@@ -139,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding documentation for running Add_Atlas_to_DB.ipynb so someone can deposit their csv compound table as an atlas. Also updated the notebook itself to sort the csv before adding it to the database and added checks on parameters/formatting.