### PR TITLE
fix: updated pandas to 2.1.2

### DIFF
--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -17,7 +17,7 @@ matchms==0.20.0
 matplotlib
 numpy==1.24.4
 oauth2client
-pandas==2.1.1
+pandas==2.1.2
 papermill
 pubchempy
 pydantic

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -281,7 +281,7 @@ packaging==23.2
     #   matplotlib
     #   nbconvert
     #   tables
-pandas==2.1.1
+pandas==2.1.2
     # via -r requirements.in
 pandocfilters==1.5.0
     # via nbconvert

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ notebooks = [
 pytest_deps = [
     "coverage==7.0.5",
     "iniconfig==2.0.0",
-    "pandas==2.1.1",
+    "pandas==2.1.2",
     "pluggy==1.0.0",
     "py==1.11.0",
     "pytest==7.2.1",


### PR DESCRIPTION
Update to fix obscure pandas import error. Previously pinned version of pandas (2.1.1) has an incorrectly pinned version of numpy, which causes numpy 2.0 to be installed resulting in an error. This update upgrades pandas to 2.1.2, which correctly pins numpy and prevents this error. 

Related Numpy issue (though it is actually an issue with Pandas):
https://github.com/numpy/numpy/issues/26710 