### PR TITLE
Rtwindow snap fix

### DIFF
--- a/metatlas/plots/dill2plots.py
+++ b/metatlas/plots/dill2plots.py
@@ -865,13 +865,17 @@ class adjust_rt_for_selected_compound(object):
         out = []
         cid_mz_ref = cid.mz_references[0].mz
         cid_mass = cid.compound[0].mono_isotopic_molecular_weight
+        cid_inchikey_prefix = cid.compound[0].inchi_key.split('-')[0]
         for compound_iter_idx, _ in enumerate(self.data[0]):
             cpd_iter_id = self.data[0][compound_iter_idx]['identification']
             if len(cpd_iter_id.compound) == 0 or is_remove(ma_data.extract(cpd_iter_id, ["ms1_notes"])):
                 continue
             mass = cpd_iter_id.compound[0].mono_isotopic_molecular_weight
             mz_ref = cpd_iter_id.mz_references[0].mz
-            if (mz_ref-0.005 <= cid_mz_ref <= mz_ref+0.005) or (mass-0.005 <= cid_mass <= mass+0.005):
+            inchikey_prefix = cpd_iter_id.compound[0].inchi_key.split('-')[0]
+            if (mz_ref-0.005 <= cid_mz_ref <= mz_ref+0.005) or \
+                (mass-0.005 <= cid_mass <= mass+0.005) or \
+                (cid_inchikey_prefix == inchikey_prefix):
                 out.append({'index': compound_iter_idx,
                             'label': cpd_iter_id.name if use_labels else cpd_iter_id.compound[0].name,
                             'rt': self.data.rts[compound_iter_idx],


### PR DESCRIPTION
The RT windows for labeled/unlabeled ISTDs were not showing up on each other's MS1 plot. This made it difficult to assign RT bounds using labeled compounds and have them translated directly to the unlabeled compounds (to make sure ISTDs had the correct bounds). This change adds a new rule that if inchi key prefixes (first section) are matching, classify compounds as "similar". This change may affect other compound relationships, so note any oddities during analysis.