### PR TITLE
feat: rename untargeted results files by shorthand for easier downstream use

### DIFF
--- a/metatlas/untargeted/run_untargeted_pipeline.py
+++ b/metatlas/untargeted/run_untargeted_pipeline.py
@@ -54,7 +54,8 @@ def main():
     ##### Step 7/7: Zipping up and (optionally) uploading output folders to gdrive
     mzm.zip_and_upload_untargeted_results(download_folder=args.download_dir,output_dir=args.output_dir,upload=args.gdrive_upload,overwrite_zip=args.overwrite_zip, \
                                           overwrite_drive=args.overwrite_drive, min_features_admissible=args.min_features, skip_zip_upload=step_bools[6], \
-                                          add_documentation=args.add_gnps2_documentation,doc_name=args.gnps2_doc_name,direct_input=args.direct_input)
+                                          add_documentation=args.add_gnps2_documentation,doc_name=args.gnps2_doc_name,direct_input=args.direct_input, \
+                                          abridged_filenames=args.abridged_filenames)
 
     ##### End the script
     end_message = mzm.end_script(script="run_untargeted_pipeline.py")
@@ -86,6 +87,7 @@ def add_arguments(parser):
     parser.add_argument('--min_features', type=int, default=0, help='Set minimum number of MZmine features for a project polarity to be zipped')
     parser.add_argument('--add_gnps2_documentation', type=bool, default=True, help='File name of the GNPS2 documentation to add to project zips')
     parser.add_argument('--gnps2_doc_name', type=str, default='Untargeted_metabolomics_GNPS2_Guide.docx', help='File name of the GNPS2 documentation to add to project zips')
+    parser.add_argument('--abridged_filenames', type=bool, default=True, help='Use abridged filenames in the zipped folders. Can be set to False for non-conforming project names')
     ## Logger/helper
     parser.add_argument('--log_file', type=str, default='/global/cfs/cdirs/m2650/untargeted_logs/untargeted_pipeline.log', help='Log file name with full path')
     parser.add_argument('--log_level', type=str, default='INFO', help='Logger level. One of [DEBUG, INFO, WARNING, ERROR, or CRITICAL]')

--- a/metatlas/untargeted/tools.py
+++ b/metatlas/untargeted/tools.py
@@ -218,8 +218,8 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                                 os.remove(neg_mzmine_job_id_filename)
                             if os.path.exists(pos_mzmine_job_id_filename):
                                 os.remove(pos_mzmine_job_id_filename)
-                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=True)
-                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=True)
+                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=abridged_filenames)
+                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=abridged_filenames)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -257,7 +257,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                             pos_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'positive'),'%s_%s_mzmine-job-id.txt'%(project_name, 'positive'))
                             if os.path.exists(pos_mzmine_job_id_filename):
                                 os.remove(pos_mzmine_job_id_filename)
-                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=True)
+                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=abridged_filenames)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -295,7 +295,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                             neg_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'negative'),'%s_%s_mzmine-job-id.txt'%(project_name, 'negative'))
                             if os.path.exists(neg_mzmine_job_id_filename):
                                 os.remove(neg_mzmine_job_id_filename)
-                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=True)
+                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=abridged_filenames)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -330,7 +330,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
 def untargeted_file_rename(target_dir="", abridged_filenames=True):
     if not abridged_filenames:
         return
-    if not target_dir:
+    if target_dir == "":
         logging.warning(tab_print("Warning! No target directory provided for renaming untargeted results files, but rename function is set to True.", 1))
         return
 

--- a/metatlas/untargeted/tools.py
+++ b/metatlas/untargeted/tools.py
@@ -341,7 +341,14 @@ def untargeted_file_rename(target_dir="", abridged_filenames=True):
     pid = old_project_name.split('_')[3]
     chromatography = old_project_name.split('_')[7]
     polarity = old_project_name.split('_')[9]
-    new_project_name = f"{date}_{department}_{submitter}_{pid}_{chromatography}_{polarity}"
+    
+    if not any(substring.lower() in department.lower() for substring in ['JGI', 'EB', 'EGSB']) or \
+        any(substring.lower() in chromatography.lower() for substring in ['C18', 'LIPID', 'HILIC']) or \
+        any(substring.lower() in polarity.lower() for substring in ['negative', 'positive']):
+            logging.warning(tab_print("Warning! Project name %s does not follow the standard naming convention. Skipping renaming..."%(old_project_name), 1))
+            return
+    else:
+        new_project_name = f"{date}_{department}_{submitter}_{pid}_{chromatography}_{polarity}"
 
     for root, dirs, files in os.walk(target_dir):
         for file in files:

--- a/metatlas/untargeted/tools.py
+++ b/metatlas/untargeted/tools.py
@@ -140,7 +140,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                                       output_dir = '/global/cfs/cdirs/metatlas/projects/untargeted_tasks', \
                                       upload=True, overwrite_zip=False, overwrite_drive=False, direct_input=None, \
                                       min_features_admissible=0, add_documentation=True, \
-                                      doc_name=None,skip_zip_upload=False):
+                                      doc_name=None,skip_zip_upload=False,abridged_filenames=True):
     """
     This function is called by export_untargeted_results.py
     
@@ -212,12 +212,14 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                             neg_directory = os.path.join(output_dir, '%s_%s'%(project_name, 'negative'))
                             pos_directory = os.path.join(output_dir, '%s_%s'%(project_name, 'positive'))
                             # Get rid of the mzmine job id files
-                            neg_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'negative'),'%s_%s_mzmine-job-id.txt'%(project_name, 'negative'))
-                            pos_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'positive'),'%s_%s_mzmine-job-id.txt'%(project_name, 'positive'))
+                            neg_mzmine_job_id_filename = os.path.join(neg_directory,'%s_%s_mzmine-job-id.txt'%(project_name, 'negative'))
+                            pos_mzmine_job_id_filename = os.path.join(pos_directory,'%s_%s_mzmine-job-id.txt'%(project_name, 'positive'))
                             if os.path.exists(neg_mzmine_job_id_filename):
                                 os.remove(neg_mzmine_job_id_filename)
                             if os.path.exists(pos_mzmine_job_id_filename):
                                 os.remove(pos_mzmine_job_id_filename)
+                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=True)
+                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=True)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -255,6 +257,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                             pos_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'positive'),'%s_%s_mzmine-job-id.txt'%(project_name, 'positive'))
                             if os.path.exists(pos_mzmine_job_id_filename):
                                 os.remove(pos_mzmine_job_id_filename)
+                            untargeted_file_rename(target_dir=pos_directory, abridged_filenames=True)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -292,6 +295,7 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
                             neg_mzmine_job_id_filename = os.path.join(output_dir,'%s_%s'%(project_name, 'negative'),'%s_%s_mzmine-job-id.txt'%(project_name, 'negative'))
                             if os.path.exists(neg_mzmine_job_id_filename):
                                 os.remove(neg_mzmine_job_id_filename)
+                            untargeted_file_rename(target_dir=neg_directory, abridged_filenames=True)
                             if add_documentation == True:
                                 logging.info(tab_print("Downloading latest GNPS2 user guide documentation to add to zip...", 1))
                                 doc_present = add_gnps2_documentation(download_folder=download_folder,doc_name=doc_name)
@@ -321,6 +325,31 @@ def zip_and_upload_untargeted_results(download_folder = '/global/cfs/cdirs/metat
             logging.info(tab_print("No new untargeted projects to be zipped.", 1))
         
         logging.info(tab_print("%s new untargeted projects completed and uploaded."%(upload_count), 1))
+
+
+def untargeted_file_rename(target_dir="", abridged_filenames=True):
+    if not abridged_filenames:
+        return
+    if not target_dir:
+        logging.warning(tab_print("Warning! No target directory provided for renaming untargeted results files, but rename function is set to True.", 1))
+        return
+
+    old_project_name = os.path.basename(target_dir)
+    date = old_project_name.split('_')[0]
+    department = old_project_name.split('_')[1]
+    submitter = old_project_name.split('_')[2]
+    pid = old_project_name.split('_')[3]
+    chromatography = old_project_name.split('_')[7]
+    polarity = old_project_name.split('_')[9]
+    new_project_name = f"{date}_{department}_{submitter}_{pid}_{chromatography}_{polarity}"
+
+    for root, dirs, files in os.walk(target_dir):
+        for file in files:
+            if old_project_name in file:
+                new_file = file.replace(old_project_name, new_project_name)
+                os.rename(os.path.join(root, file), os.path.join(root, new_file))
+    
+    logging.info(tab_print(f"Files for project {old_project_name} renamed with new prefix: {new_project_name}", 1))
 
 
 def check_peak_height_table(peak_height_file):


### PR DESCRIPTION
Suzie noted an issue with the untargeted outputs where windows computers cannot open files with very long pathnames. This fix pares down the untargeted output filenames and will only work on newer project names.