### PR TITLE
Fix rt_min/max_delta parameter passing to RT alignment

### DIFF
--- a/metatlas/datastructures/metatlas_dataset.py
+++ b/metatlas/datastructures/metatlas_dataset.py
@@ -147,8 +147,8 @@ class MetatlasDataset(HasTraits):
     keep_nonmatches: bool = Bool(default_value=True)
     ids: analysis_ids.AnalysisIdentifiers = Instance(klass=analysis_ids.AnalysisIdentifiers)
     atlas: metob.Atlas = Instance(klass=metob.Atlas)
-    rt_min_delta = Int(allow_none=True, default_value=None)
-    rt_max_delta = Int(allow_none=True, default_value=None)
+    rt_min_delta = Float(allow_none=True, default_value=None)
+    rt_max_delta = Float(allow_none=True, default_value=None)
     _atlas_df: Optional[pd.DataFrame] = Instance(klass=pd.DataFrame, allow_none=True, default_value=None)
     # _all_data contanis all data in experiement before any filtering
     _all_data: Optional[SampleSet] = traitlets.Tuple(allow_none=True, default_value=None)

--- a/metatlas/targeted/rt_alignment.py
+++ b/metatlas/targeted/rt_alignment.py
@@ -107,6 +107,7 @@ def generate_rt_alignment_models(
     Returns a tuple with linear, polynomial and offset models
     """
     params = workflow.rt_alignment.parameters
+    logger.info("Generating RT alignment models with QC atlas %s and RT expansion of %s and %s", workflow.rt_alignment.atlas.name, params.rt_min_delta, params.rt_max_delta)
     rts_df = get_rts(data)
     actual, pred = subset_data_for_model_input(
         params.dependent_data_source, rts_df, data.atlas_df, params.inchi_keys_not_in_model
@@ -447,7 +448,7 @@ def write_notebooks(
                         before processing of the config file
     Returns a list of Paths to notebooks
     """
-    parameters_not_to_forward = ["rt_min_delta", "rt_max_delta"]
+    parameters_not_to_forward = []
     out = []
     for atlas, analysis in zip(atlases, workflow.analyses):
         source = repo_path() / "notebooks" / "reference" / "Targeted.ipynb"
@@ -488,6 +489,7 @@ def run(
     )
     shutil.copy2(params.config_file_name, ids.output_dir)
     ids.set_output_state(params, "rt_alignment")
-    metatlas_dataset = MetatlasDataset(ids=ids, max_cpus=params.max_cpus)
+    #metatlas_dataset = MetatlasDataset(ids=ids, max_cpus=params.max_cpus, rt_min_delta=params.rt_min_delta, rt_max_delta=params.rt_max_delta)
+    metatlas_dataset = MetatlasDataset(ids=ids, max_cpus=params.max_cpus, rt_min_delta=params.rt_min_delta, rt_max_delta=params.rt_max_delta)
     generate_outputs(metatlas_dataset, workflow, set_parameters)
     return metatlas_dataset

--- a/metatlas/tools/config.py
+++ b/metatlas/tools/config.py
@@ -67,8 +67,6 @@ class BaseNotebookParameters(BaseModel):
     include_lcmsruns: OutputLists = OutputLists()
     exclude_lcmsruns: OutputLists = OutputLists()
     groups_controlled_vocab: List[str] = []
-    rt_min_delta: Optional[float] = None
-    rt_max_delta: Optional[float] = None
     mz_tolerance_default: float = 10  # units of ppm
     mz_tolerance_override: Optional[float] = None  # units of ppm
     frag_mz_tolerance: Optional[float] = 0.02  # units of Daltons
@@ -135,7 +133,8 @@ class RTAlignmentNotebookParameters(BaseNotebookParameters):
     stop_before: Optional[str] = None
     google_folder: str
     msms_refs: Path
-
+    rt_min_delta: Optional[float] = None
+    rt_max_delta: Optional[float] = None
 
 class Atlas(BaseModel):
     """Atlas specification"""


### PR DESCRIPTION
1. Moved rt_min/max_delta parameters to RT alignment routine config only because they were getting excluded from being passed to Analysis routines anyways
2. Changed allowable type from traitlets Int to Float because every time a float was being passed it was not registering
3. In the rt_alignment.run() function, rt_min/max_delta were specifically passed to the MetatlasDataset object so they were assigned (rather than given default None)