### PR TITLE
Increase lock wait time to 7200s (2 hrs) to avoid exit failure

### DIFF
--- a/metatlas/datastructures/object_helpers.py
+++ b/metatlas/datastructures/object_helpers.py
@@ -121,7 +121,7 @@ class Workspace(object):
         logger.debug('Using database at: %s', self.get_database_path(with_password=False))
         self.path = self.get_database_path(with_password=True)
         mysql_kwargs = {"pool_recycle": 3600, "connect_args": {"connect_timeout": 120}}
-        sqlite_kwargs = {"connect_args": {"timeout": 0.01}}
+        sqlite_kwargs = {"connect_args": {"timeout": 7200}}
         self.engine_kwargs = sqlite_kwargs if self.path.startswith("sqlite") else mysql_kwargs
 
         self.tablename_lut = {}


### PR DESCRIPTION
I had previously had changed the lock wait time from default (50 secs) to 0.01 secs to reproduce the lock wait error in the dev environment. Here, I'm increasing it to 7200s which is longer than the longest targeted run to date. This will allow the MySQL queries to wait in a queue while another user accesses the relevant tables instead of exiting with an error.